### PR TITLE
Fix useContext crash in BreakoutScene

### DIFF
--- a/apps/breakout-game/src/Game.tsx
+++ b/apps/breakout-game/src/Game.tsx
@@ -18,6 +18,8 @@ export default function Game() {
         ...config.scene,
         create: function () {
           this.registry.set('angleFactor', angleFactor);
+          const marketData = this.registry.get('marketData');
+          this.registry.set('marketData', marketData);
         }
       }
     });

--- a/apps/breakout-game/src/context/MarketDataContext.tsx
+++ b/apps/breakout-game/src/context/MarketDataContext.tsx
@@ -11,6 +11,9 @@ export interface MarketData {
 
 interface MarketDataProviderType {
   marketData: MarketData[];
+  toggleDataSource: () => void;
+  isLoading: boolean;
+  hasError: boolean;
 }
 
 export const MarketDataContext = createContext<MarketDataProviderType | undefined>(undefined);
@@ -18,23 +21,43 @@ export const MarketDataContext = createContext<MarketDataProviderType | undefine
 export function MarketDataProvider({ children }: { children: ReactNode }) {
   const [marketData, setMarketData] = useState<MarketData[]>([]);
   const [useLiveData, setUseLiveData] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasError, setHasError] = useState(false);
+
+  const API_URL = process.env.REACT_APP_MARKET_API_URL || "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd";
+  const MOCK_API_URL = "/api/mock-market";
+  const POLL_INTERVAL_MS = process.env.REACT_APP_MARKET_DATA_POLL_INTERVAL_MS ? parseInt(process.env.REACT_APP_MARKET_DATA_POLL_INTERVAL_MS) : 10000;
 
   useEffect(() => {
     const fetchMarketData = async () => {
+      setIsLoading(true);
+      setHasError(false);
       try {
         const data = useLiveData
-          ? await fetch("https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd").then(res => res.json())
-          : await fetch("/api/mock-market").then(res => res.json());
-        setMarketData(data);
+          ? await fetch(API_URL).then(res => res.json())
+          : await fetch(MOCK_API_URL).then(res => res.json());
+
+        const validatedData = Array.isArray(data) ? data.map(item => ({
+          asset: item.asset || item.id || 'unknown',
+          price: typeof item.price === 'number' ? item.price : parseFloat(item.current_price) || 0,
+          volume: typeof item.volume === 'number' ? item.volume : parseFloat(item.total_volume) || 0,
+          liquidity: typeof item.liquidity === 'number' ? item.liquidity : parseFloat(item.market_cap) || 0,
+          trend: item.trend || (item.price_change_percentage_24h > 0 ? 'bull' : item.price_change_percentage_24h < 0 ? 'bear' : 'neutral'),
+          updatedAt: item.updatedAt || Date.now()
+        })) : [];
+
+        setMarketData(validatedData);
       } catch (error) {
         console.error("Failed to fetch market data:", error);
-        // Provide fallback data or handle error state
+        setHasError(true);
         setMarketData([]);
+      } finally {
+        setIsLoading(false);
       }
     };
 
     fetchMarketData();
-    const interval = setInterval(fetchMarketData, 10000); // Poll every 10s
+    const interval = setInterval(fetchMarketData, POLL_INTERVAL_MS);
     return () => clearInterval(interval);
   }, [useLiveData]);
 
@@ -43,7 +66,7 @@ export function MarketDataProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <MarketDataContext.Provider value={{ marketData, toggleDataSource }}>
+    <MarketDataContext.Provider value={{ marketData, toggleDataSource, isLoading, hasError }}>
       {children}
     </MarketDataContext.Provider>
   );

--- a/apps/breakout-game/src/contexts/GameContext.tsx
+++ b/apps/breakout-game/src/contexts/GameContext.tsx
@@ -6,8 +6,7 @@ import type React from "react"
 
 import { createContext, useContext, useState, useRef, type ReactNode } from "react"
 import type { Ball, Paddle, Pixel, PowerUp, PointLossIndicator } from "@/types/game-types"
-import { LEVEL_THEMES } from "@/utils/constants"
-import { MarketDataContext } from '../context/MarketDataContext';
+import { LEVEL_THEMES } from "@/utils/constants";
 
 interface GameState {
   score: number
@@ -35,7 +34,6 @@ interface GameState {
   educationalProgress: Record<string, boolean>
   performanceMetrics: Record<string, number>
   angleFactor: number // Added angleFactor property
-  marketData: any // Added marketData property
 }
 
 interface GameContextType {
@@ -103,7 +101,6 @@ const defaultGameState: GameState = {
   educationalProgress: {},
   performanceMetrics: {},
   angleFactor: 5, // Initialized angleFactor
-  marketData: null // Initialized marketData
 }
 
 const GameContext = createContext<GameContextType | undefined>(undefined)
@@ -140,17 +137,6 @@ export function GameProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     gameStateRef.current = gameState
   }, [gameState])
-
-  // Fetch market data from context
-  const { marketData } = useContext(MarketDataContext);
-
-  // Update game state with market data
-  useEffect(() => {
-    setGameState((prev) => ({
-      ...prev,
-      marketData
-    }));
-  }, [marketData]);
 
   const getCurrentLevelTheme = () => {
     const levelIndex = (gameState.level - 1) % LEVEL_THEMES.length

--- a/apps/breakout-game/src/scenes/BreakoutScene.ts
+++ b/apps/breakout-game/src/scenes/BreakoutScene.ts
@@ -1,7 +1,4 @@
 import { Ball } from '../objects/Ball';
-import { useGameContext } from '../contexts/GameContext';
-import { useContext } from 'react';
-import { MarketDataContext } from '../context/MarketDataContext';
 
 class BreakoutScene extends Phaser.Scene {
 	private paddle!: Phaser.Physics.Arcade.Sprite;
@@ -16,6 +13,7 @@ class BreakoutScene extends Phaser.Scene {
 	private angleFactor: number = 5; // Default value, will be updated from context
 	private powerUps!: Phaser.Physics.Arcade.Group; // Group to hold power-ups
 	private marketData: any; // Placeholder for market data
+	private marketOverlayText!: Phaser.GameObjects.Text; // Placeholder for market overlay text
   
 	constructor(angleFactor: number) {
 	  super({ key: 'Breakout', active: true });
@@ -77,9 +75,15 @@ class BreakoutScene extends Phaser.Scene {
 		runChildUpdate: true
 	  });
 
-	// Fetch market data from context
-	const { marketData } = useContext(MarketDataContext);
-	this.marketData = marketData;
+	// Fetch market data from registry
+	this.marketData = this.registry.get('marketData');
+
+	// Create market overlay text
+	this.marketOverlayText = this.add.text(20, 60, '', {
+		fontSize: '18px',
+		color: '#FFFFFF',
+		fontFamily: 'Arial'
+	  }).setScrollFactor(0);
   
 	}
   
@@ -283,11 +287,7 @@ class BreakoutScene extends Phaser.Scene {
 	  private displayMarketDataOverlay() {
 		if (this.marketData) {
 		  const overlayText = `Price: ${this.marketData.price}, Volume: ${this.marketData.volume}, Trend: ${this.marketData.trend}`;
-		  this.add.text(20, 60, overlayText, {
-			fontSize: '18px',
-			color: '#FFFFFF',
-			fontFamily: 'Arial'
-		  }).setScrollFactor(0);
+		  this.marketOverlayText.setText(overlayText);
 		}
 	  }
   }


### PR DESCRIPTION
Refactor the BreakoutScene to remove React hooks and use Phaser's registry for market data.

* **BreakoutScene.ts**
  - Remove `useContext` and `useGameContext` imports.
  - Retrieve market data using `this.registry.get('marketData')`.
  - Create `marketOverlayText` once and update its content in `displayMarketDataOverlay`.

* **MarketDataContext.tsx**
  - Add `toggleDataSource`, `isLoading`, and `hasError` to `MarketDataProviderType` interface.
  - Move API URLs to constants.
  - Add data validation and error handling.
  - Add loading and error states.
  - Make polling interval configurable via environment variable.

* **GameContext.tsx**
  - Remove `useContext` import for `MarketDataContext`.
  - Remove market data fetching logic.
  - Update `defaultGameState` to remove `marketData`.
  - Remove `marketData` from `GameContextType`.

* **Game.tsx**
  - Add `scene.registry.set('marketData', marketData)` in `create` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phoenixvc/vv-game-suite?shareId=XXXX-XXXX-XXXX-XXXX).