### PR TITLE
Fix power-up usage in BreakoutScene

### DIFF
--- a/apps/breakout-game/src/contexts/GameContext.tsx
+++ b/apps/breakout-game/src/contexts/GameContext.tsx
@@ -34,6 +34,7 @@ interface GameState {
   educationalProgress: Record<string, boolean>
   performanceMetrics: Record<string, number>
   angleFactor: number // Added angleFactor property
+  collectedPowerUps: PowerUp[] // Added collectedPowerUps property
 }
 
 interface GameContextType {
@@ -101,6 +102,7 @@ const defaultGameState: GameState = {
   educationalProgress: {},
   performanceMetrics: {},
   angleFactor: 5, // Initialized angleFactor
+  collectedPowerUps: [] // Initialized collectedPowerUps
 }
 
 const GameContext = createContext<GameContextType | undefined>(undefined)
@@ -232,10 +234,10 @@ export function GameProvider({ children }: { children: ReactNode }) {
   };
 
   const collectPowerUp = (powerUp: PowerUp) => {
-    applyPowerUpEffect(powerUp);
-    setTimeout(() => {
-      removePowerUpEffect(powerUp);
-    }, powerUp.duration);
+    setGameState((prev) => ({
+      ...prev,
+      collectedPowerUps: [...prev.collectedPowerUps, powerUp],
+    }));
   };
 
   const applyPowerUpEffect = (powerUp: PowerUp) => {
@@ -270,6 +272,19 @@ export function GameProvider({ children }: { children: ReactNode }) {
     return gameState.angleFactor;
   }
 
+  useEffect(() => {
+    const handleCollectPowerUp = (event: CustomEvent) => {
+      const { type, duration } = event.detail;
+      const powerUp: PowerUp = { x: 0, y: 0, type, duration }; // Example power-up object
+      collectPowerUp(powerUp);
+    };
+
+    window.addEventListener('collectPowerUp', handleCollectPowerUp as EventListener);
+
+    return () => {
+      window.removeEventListener('collectPowerUp', handleCollectPowerUp as EventListener);
+    };
+  }, []);
 
   // TODO: Avoid Inline Functions in Context Value 
   // If you use useMemo, ensure all functions used in the context value are either stable (useCallback) or defined outside the render.

--- a/apps/breakout-game/src/scenes/BreakoutScene.ts
+++ b/apps/breakout-game/src/scenes/BreakoutScene.ts
@@ -1,5 +1,5 @@
 import { Ball } from '../objects/Ball';
-import { useGameContext } from '../contexts/GameContext';
+import { PowerUpType } from '../types/PowerUp';
 
 class BreakoutScene extends Phaser.Scene {
 	private paddle!: Phaser.Physics.Arcade.Sprite;
@@ -271,7 +271,7 @@ class BreakoutScene extends Phaser.Scene {
 	  }
 
 	private createPowerUp(x: number, y: number) {
-		const powerUpTypes = ['extraLife', 'paddleGrow']; // Add other power-up types here
+		const powerUpTypes = [PowerUpType.EXTRA_LIFE, PowerUpType.PADDLE_GROW]; // Add other power-up types here
 		const type = powerUpTypes[Phaser.Math.Between(0, powerUpTypes.length - 1)];
 		const powerUp = this.physics.add.image(x, y, `powerup_${type}`);
 		powerUp.setVelocityY(150);
@@ -279,9 +279,8 @@ class BreakoutScene extends Phaser.Scene {
 	  }
 	  
 	  private collectPowerUp(paddle: Phaser.Physics.Arcade.Sprite, powerUp: Phaser.Physics.Arcade.Image) {
-		const { collectPowerUp } = useGameContext();
-		const type = powerUp.texture.key.replace('powerup_', '');
-		collectPowerUp({ type, duration: 10000 }); // Example duration
+		const type = powerUp.texture.key.replace('powerup_', '') as PowerUpType;
+		this.events.emit('collectPowerUp', { type, duration: 10000 }); // Example duration
 		powerUp.destroy();
 	  }
 

--- a/apps/breakout-game/src/types/PowerUp.ts
+++ b/apps/breakout-game/src/types/PowerUp.ts
@@ -21,25 +21,89 @@ export class PowerUp extends Phaser.Physics.Arcade.Sprite {
     this.setVelocityY(150); // Falls down by default
   }
 
-  applyEffect(game: GameScene) {
+  applyEffect(game: Phaser.Scene) {
     switch (this.type) {
       case PowerUpType.EXTRA_LIFE:
-        game.addLife();
+        if ('addLife' in game && typeof game.addLife === 'function') {
+          game.addLife();
+        }
         break;
       case PowerUpType.PADDLE_GROW:
-        game.paddle.setScale(1.5, 1);
-        game.setPowerUpTimer(this, 10000); // 10 seconds
+        if ('paddle' in game && game.paddle instanceof Phaser.GameObjects.Sprite) {
+          game.paddle.setScale(1.5, 1);
+        }
+        if ('setPowerUpTimer' in game && typeof game.setPowerUpTimer === 'function') {
+          game.setPowerUpTimer(this, 10000); // 10 seconds
+        }
         break;
-      // ...other cases
+      case PowerUpType.PADDLE_SHRINK:
+        if ('paddle' in game && game.paddle instanceof Phaser.GameObjects.Sprite) {
+          game.paddle.setScale(0.5, 1);
+        }
+        if ('setPowerUpTimer' in game && typeof game.setPowerUpTimer === 'function') {
+          game.setPowerUpTimer(this, 10000); // 10 seconds
+        }
+        break;
+      case PowerUpType.MULTI_BALL:
+        if ('addMultiBall' in game && typeof game.addMultiBall === 'function') {
+          game.addMultiBall();
+        }
+        break;
+      case PowerUpType.SPEED_UP:
+        if ('ball' in game && game.ball instanceof Phaser.Physics.Arcade.Sprite) {
+          game.ball.setVelocity(game.ball.body.velocity.x * 1.5, game.ball.body.velocity.y * 1.5);
+        }
+        if ('setPowerUpTimer' in game && typeof game.setPowerUpTimer === 'function') {
+          game.setPowerUpTimer(this, 10000); // 10 seconds
+        }
+        break;
+      case PowerUpType.STICKY:
+        if ('paddle' in game && game.paddle instanceof Phaser.GameObjects.Sprite) {
+          game.paddle.setSticky(true);
+        }
+        if ('setPowerUpTimer' in game && typeof game.setPowerUpTimer === 'function') {
+          game.setPowerUpTimer(this, 10000); // 10 seconds
+        }
+        break;
+      case PowerUpType.LASER:
+        if ('enableLaser' in game && typeof game.enableLaser === 'function') {
+          game.enableLaser();
+        }
+        break;
+      case PowerUpType.SHIELD:
+        if ('addShield' in game && typeof game.addShield === 'function') {
+          game.addShield();
+        }
+        break;
+      default:
+        console.warn(`Unknown power-up type: ${this.type}`);
+        break;
     }
   }
 
   removeEffect(game: Phaser.Scene) {
-    if (this.type === PowerUpType.PADDLE_GROW) {
-      if ('paddle' in game && game.paddle instanceof Phaser.GameObjects.Sprite) {
-        game.paddle.setScale(1, 1);
-      }
+    switch (this.type) {
+      case PowerUpType.PADDLE_GROW:
+        if ('paddle' in game && game.paddle instanceof Phaser.GameObjects.Sprite) {
+          game.paddle.setScale(1, 1);
+        }
+        break;
+      case PowerUpType.PADDLE_SHRINK:
+        if ('paddle' in game && game.paddle instanceof Phaser.GameObjects.Sprite) {
+          game.paddle.setScale(1, 1);
+        }
+        break;
+      case PowerUpType.SPEED_UP:
+        if ('ball' in game && game.ball instanceof Phaser.Physics.Arcade.Sprite) {
+          game.ball.setVelocity(game.ball.body.velocity.x / 1.5, game.ball.body.velocity.y / 1.5);
+        }
+        break;
+      case PowerUpType.STICKY:
+        if ('paddle' in game && game.paddle instanceof Phaser.GameObjects.Sprite) {
+          game.paddle.setSticky(false);
+        }
+        break;
+      // Add other power-up expiration logic here
     }
-    // ...other cases
   }
 }


### PR DESCRIPTION
Refactor `collectPowerUp` method in `BreakoutScene.ts` to remove `useGameContext` usage and dispatch custom event.

* Import `PowerUpType` enum in `BreakoutScene.ts` and replace string literals with enum values.
* Add type guards in `PowerUp.ts` to verify the existence and type of properties and methods before using them.
* Implement fallback mechanism in `PowerUp.ts` to handle unknown power-up types.
* Create a custom event in `GameContext.tsx` to handle power-up collection logic.
* Listen for the custom event in `GameContext.tsx` and update shared state with collected power-ups.
* Implement actual logic for each power-up type in `PowerUp.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phoenixvc/vv-game-suite/pull/22?shareId=39d16b75-d1cd-4979-9f94-4bdba5951dfb).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded support for additional power-up types, including Paddle Shrink, Multi Ball, Speed Up, Sticky, Laser, and Shield, each with distinct effects.
	- Collected power-ups are now tracked and displayed during gameplay.
- **Improvements**
	- Enhanced type safety and reliability when applying and removing power-up effects.
	- Power-up effects are now managed more robustly, with clear handling for activation and expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->